### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/balboa/manifest.json
+++ b/custom_components/balboa/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "balboa",
   "name": "Balboa Spa Client",
+  "version": "0.6.0",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/balboa",
   "requirements": [


### PR DESCRIPTION
Fixes issue #21. Add the now required version attribute to the component manifest.json. Tested change locally and confirmed the integration lists and loads again. Note that if you are going to cut a new release to include this change, you'll want to reflect the updated version in the manifest file!